### PR TITLE
Highlight message author in graph

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -208,7 +208,7 @@ impl EventHandler for Handler {
                             social.build_guild_graph(guild_id).unwrap()
                         };
 
-                        let dot = graph.to_dot(&ctx, &self.cache, guild_id);
+                        let dot = graph.to_dot(&ctx, &self.cache, guild_id, &new_message.author);
 
                         let mut graphviz = std::process::Command::new("dot")
                             .arg("-v")
@@ -262,7 +262,7 @@ impl EventHandler for Handler {
                                 social.build_guild_graph(guild_id).unwrap()
                             };
 
-                            let dot = graph.to_dot(&ctx, &self.cache, guild_id);
+                            let dot = graph.to_dot(&ctx, &self.cache, guild_id, &new_message.author);
                             let guild_name = self.cache.get_guild(&ctx, guild_id).unwrap().name;
                             files.push((dot, format!("{}.dot", guild_name)));
                         }

--- a/src/social.rs
+++ b/src/social.rs
@@ -82,7 +82,7 @@ impl UserRelationshipGraphMap {
         }
     }
 
-    pub fn to_dot(&self, ctx: &Context, cache: &Cache, guild_id: GuildId) -> String {
+    pub fn to_dot(&self, ctx: &Context, cache: &Cache, guild_id: GuildId, author : &User) -> String {
         // Gather all undirected edges.
         let mut undirected_edges = HashMap::new();
         for (&(source, target), new_weight) in &self.0 {
@@ -163,11 +163,18 @@ impl UserRelationshipGraphMap {
         for (user_id, weight) in &user_weights {
             let name = names.get(user_id).unwrap().clone();
             let width = 1.0 + weight.log10();
+
+            let mut color = "black";
+            if *user_id == author.id {
+                color = "darkgoldenrod1";
+            }
+
             lines.push(format!(
-                "    {} [ label = \"{}\", penwidth = \"{}\" ]",
+                "    {} [ label = \"{}\", penwidth = \"{}\", color={}]",
                 user_id,
                 get_label(name).replace("\"", "\\\""),
                 width,
+                color,
             ));
         }
 


### PR DESCRIPTION
This highlights the user who requested the graph in the image to allow people to more easily find themselves. I chose the color  `darkgoldenrod1` since it's yellow-ish but still clearly visible in front of the white background. [Here's](http://www.graphviz.org/doc/info/colors.html) a quick link to the color list if this one isn't preferred.


This results in the following graph generation.

![DiscordCompiler_Support](https://user-images.githubusercontent.com/11095737/91548803-d1e23980-e8da-11ea-8274-306fbba0f336.png)


If you have other design plans in place and want to trash this PR that's completely fine - this was just for me to dip my toes into the project.