### PR TITLE
Remove concept of environments

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -191,7 +191,7 @@ pub struct CacheStats {
 impl Cache {
     pub fn new() -> Self {
         // TODO: Tune these cache sizes.
-        const CACHE_LIMIT: usize = 1000;
+        const CACHE_LIMIT: usize = 5000;
 
         Cache {
             users: Mutex::new(LruCache::new(CACHE_LIMIT)),


### PR DESCRIPTION
We now have separate Discord applications for production and development, which is a lot easier to manage.