### PR TITLE
Fix duplicate CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ci:


### PR DESCRIPTION
GitHub runs both the `push` and `pull_request` workflows for PRs that
are coming from our own repo, which runs double the CI builds wasting
resources.

The downside of this change is that if we add multiple development lines
in the future, they'll need adding here to get CI checks.